### PR TITLE
Switched order of resolve around to check node_modules first.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitalizer",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "The Vital Software front-end asset builder.",
   "license": "MIT",
   "repository": "vital-software/vitalizer",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -282,10 +282,10 @@ module.exports = {
                 ],
 
                 modules: [
+                    'node_modules',
                     paths.appCss,
                     paths.appSrc,
-                    paths.appPublic,
-                    'node_modules'
+                    paths.appPublic
                 ]
             },
 


### PR DESCRIPTION
Moved `node_modules` to have precedence over our app directories when resolving packages. Name clashes can cause some weird outcomes that are way harder to debug if it's the other way around. Published as 3.0.3 to help fix up https://github.com/vital-software/dashboard/issues/419