### PR TITLE
allow project to specify host for webpack server

### DIFF
--- a/script/start.js
+++ b/script/start.js
@@ -122,7 +122,7 @@ function run() {
     })
 
     // Launch WebpackDevServer
-    devServer.listen(DEFAULTS.PORT, (error) => {
+    devServer.listen(DEFAULTS.PORT, DEFAULTS.HOST, (error) => {
         if (error) {
             return console.log(error)
         }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -31,6 +31,7 @@ try {
 
 // Options
 const DEFAULT_PORT = 3000
+const DEFAULT_HOST = 'localhost'
 
 const API = Object.assign(
     {
@@ -41,7 +42,7 @@ const API = Object.assign(
     appConfig.api
 )
 const PORT = appConfig.port || DEFAULT_PORT
-const HOST = 'localhost'
+const HOST = appConfig.host || DEFAULT_HOST
 const PROTOCOL = 'http'
 const URL_LOADER_LIMIT = 10000 // Byte limit for URL loader conversion
 


### PR DESCRIPTION
Docker networking does not allow `dashboard` access api that is running on the host. On windows, I start development image with flag `--networking=host`. But then, Docker does not map dashboard's port to the host's port. Instead, container has an IP address that is reachable from host's network. So webpack needs to listen on that IP address, or listen on all interfaces by specifying 0.0.0.0 as its host.

If anyone needs more details, just ask :)