### PR TITLE
Fix SSE buffering: don't use compression in the dev server

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -169,8 +169,8 @@ module.exports = {
         )
         const devServer = Object.assign(
             {
-                // Add GZip compression
-                compress: true,
+                // Can't use gzip compression, because it causes SSE buffering
+                compress: false,
 
                 // Use /static/ as the default content base
                 contentBase: paths.appPublic,


### PR DESCRIPTION
What's going on with those delayed SSEs: gzip compression, again.

To test, set up your `yarn start` on the trackboard project like usual. Then make a curl request to subscribe to some SSEs (get the curl command by loading the trackboard normally, right clicking the subscription request in the devtools network tab, "copy as curl"). You'll get a request/response like this:

```
> GET /api/graphql?query=subscription+MedicalRecordUpdate+<query>&Authorization=<authtoken> HTTP/1.1
> Host: localhost:3000
> Accept-Encoding: deflate, gzip
> Accept: text/event-stream
> Cache-Control: no-cache
> User-Agent: blah
>
< HTTP/1.1 200 OK
< X-Powered-By: Express
< content-security-policy: default-src 'self'
< Vary: Origin, Accept-Encoding
< cache-control: no-cache
< referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
< x-frame-options: DENY
< x-xss-protection: 1; mode=block
< x-accel-buffering: no
< x-content-type-options: nosniff
< x-graphql-operation-name: MedicalRecordUpdate
< x-permitted-cross-domain-policies: master-only
< date: Thu, 15 Feb 2018 04:25:14 GMT
< connection: close
< transfer-encoding: chunked
< content-type: text/event-stream
< Content-Encoding: gzip
<
```

Two things there:
 - `Content-Encoding: gzip`, which isn't sent from upstream (test by curling `:9000`)
 - The lack of an initial SSE (a blank heartbeat event should be received immediately)

Then, swap the `compress` setting to `false` like in this PR, and `yarn start` again. Now, repeating the exact same curl:

```
> GET /api/graphql?query=subscription+MedicalRecordUpdate+<query>&Authorization=<authtoken> HTTP/1.1
> Host: localhost:3000
> Accept-Encoding: deflate, gzip
> Accept: text/event-stream
> Cache-Control: no-cache
> User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36
>
< HTTP/1.1 200 OK
< X-Powered-By: Express
< content-security-policy: default-src 'self'
< vary: Origin
< cache-control: no-cache
< referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
< x-frame-options: DENY
< x-xss-protection: 1; mode=block
< x-accel-buffering: no
< x-content-type-options: nosniff
< x-graphql-operation-name: MedicalRecordUpdate
< x-permitted-cross-domain-policies: master-only
< date: Thu, 15 Feb 2018 04:27:38 GMT
< connection: close
< transfer-encoding: chunked
< content-type: text/event-stream
<
data: {"data":{"medicalRecordUpdate":null}}
```

Now we get the event straight away, and the rest come through immediately too, without buffering.

It's going to unfortunately make all the rest of the CSS/JS bigger to transfer in dev, but it's just dev; should be a fast localhost/vm connection anyway.