### PR TITLE
Fix “Tapable.plugin is deprecated” errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,4 @@
-FROM node:8.9-alpine
-
-# Install common Alpine dependencies
-#   - bash because e2e-simple.sh needs it
-RUN apk update && \
-    apk upgrade && \
-    apk add --no-cache \
-      ca-certificates \
-      git \
-      openssl \
-      bash \
-      diffutils \
-      tzdata && \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.27-r0/glibc-2.27-r0.apk && \
-    apk add --no-cache glibc-2.27-r0.apk && \
-    rm glibc-2.27-r0.apk
+FROM node:8
 
 # Set timezone
 ENV TZ=Pacific/Auckland

--- a/script/start.js
+++ b/script/start.js
@@ -43,7 +43,7 @@ function run() {
         isFirstCompile = false
     }
 
-    compiler.plugin('invalid', function() {
+    compiler.hooks.invalid.tap('invalid', () => {
         if (IS_INTERACTIVE) {
             clearConsole()
         }
@@ -52,7 +52,7 @@ function run() {
         console.log(chalk.blue(new Date().toUTCString(), ': Compiling...'))
     })
 
-    compiler.plugin('done', function(stats) {
+    compiler.hooks.done.tap('done', (stats) => {
         if (IS_INTERACTIVE) {
             // clearConsole();
         }


### PR DESCRIPTION
Had to also update the Dockerfile, as it was failing the CI. Have moved it to latest Node 8 Docker image (non-alpine)