### PR TITLE
Add CDN_URL support to JS/CSS assets

### DIFF
--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -1,4 +1,6 @@
-module.exports = {
+const CDN_URL = process.env.CDN_URL
+
+module.exports = ({ env }) => ({
     parser: 'postcss-scss',
     plugins: {
         'postcss-import': {},
@@ -16,6 +18,12 @@ module.exports = {
                 },
                 customProperties: false
             }
-        }
+        },
+        'postcss-url':
+            env === 'production' && CDN_URL
+                ? {
+                    url: ({ url }) => `${CDN_URL}${url}`
+                }
+                : false
     }
-}
+})

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -16,6 +16,8 @@ const webpack = require('webpack')
 const smp = new SpeedMeasurePlugin()
 // Configure file names to use hashing or not
 const fileName = process.env.DISABLE_HASH ? '[name]' : '[name].[chunkhash:8]'
+// Configure CDN or local urls
+const publicPath = process.env.CDN_URL ? process.env.CDN_URL : '/'
 
 /*
     This is the production configuration.
@@ -50,8 +52,8 @@ module.exports = smp.wrap({
         chunkFilename: `${fileName}.chunk.js`,
 
         // Webpack uses `publicPath` to determine where the app is being served from.
-        // We always serve from the root. This makes config easier.
-        publicPath: '/',
+        // We either serve from the root, or a CDN url. This makes config easier.
+        publicPath,
 
         // Point sourcemap entries to original disk location (format as URL on Windows)
         devtoolModuleFilenameTemplate: (info) => path.resolve(info.absoluteResourcePath).replace(/\\/g, '/')

--- a/package.json
+++ b/package.json
@@ -1,111 +1,112 @@
 {
-    "name": "vitalizer",
-    "version": "5.3.0",
-    "description": "Vital Software front-end asset builder",
-    "license": "MIT",
-    "repository": "vital-software/vitalizer",
-    "homepage": "https://github.com/vital-software/vitalizer#readme",
-    "author": "Te Riu Warren <te@vitaler.co",
-    "bugs": {
-        "url": "https://github.com/vital-software/vitalizer/issues"
-    },
-    "files": [
-        "bin",
-        "config",
-        "helper",
-        "scripts"
+  "name": "vitalizer",
+  "version": "5.3.0",
+  "description": "Vital Software front-end asset builder",
+  "license": "MIT",
+  "repository": "vital-software/vitalizer",
+  "homepage": "https://github.com/vital-software/vitalizer#readme",
+  "author": "Te Riu Warren <te@vitaler.co",
+  "bugs": {
+    "url": "https://github.com/vital-software/vitalizer/issues"
+  },
+  "files": [
+    "bin",
+    "config",
+    "helper",
+    "scripts"
+  ],
+  "release": {
+    "verifyConditions": [
+      "@semantic-release/npm",
+      "@semantic-release/git"
     ],
-    "release": {
-        "verifyConditions": [
-            "@semantic-release/npm",
-            "@semantic-release/git"
+    "prepare": [
+      "@semantic-release/npm",
+      {
+        "path": "@semantic-release/git",
+        "assets": [
+          "package.json"
         ],
-        "prepare": [
-            "@semantic-release/npm",
-            {
-                "path": "@semantic-release/git",
-                "assets": [
-                    "package.json"
-                ],
-                "message": "chore(release): ${nextRelease.version} [skip ci]"
-            }
-        ],
-        "publish": [
-            "@semantic-release/npm",
-            "@semantic-release/github"
-        ]
-    },
-    "scripts": {
-        "lint": "eslint \"{bin,config,helper,scripts}/**/*.js\" --quiet",
-        "precommit": "yarn lint",
-        "test": "./test/task/local-test.sh"
-    },
-    "bin": {
-        "vitalizer": "./bin/vitalizer.js"
-    },
-    "dependencies": {
-        "@babel/core": "7.1.5",
-        "babel-loader": "8.0.4",
-        "browserslist": "4.3.4",
-        "case-sensitive-paths-webpack-plugin": "2.1.2",
-        "chalk": "2.4.1",
-        "connect-history-api-fallback": "1.5.0",
-        "cross-spawn": "6.0.5",
-        "css-loader": "0.28.11",
-        "dotenv": "6.1.0",
-        "dotenv-expand": "4.2.0",
-        "file-loader": "1.1.11",
-        "filesize": "3.6.1",
-        "fs-extra": "6.0.1",
-        "graphql": "0.13.2",
-        "graphql-tag": "2.10.0",
-        "gzip-size": "4.1.0",
-        "html-webpack-plugin": "3.2.0",
-        "http-proxy-middleware": "0.19.0",
-        "koa-connect": "2.0.1",
-        "koa-router": "7.4.0",
-        "mini-css-extract-plugin": "0.4.4",
-        "optimize-css-assets-webpack-plugin": "4.0.3",
-        "postcss-cssnext": "3.1.0",
-        "postcss-import": "11.1.0",
-        "postcss-loader": "2.1.6",
-        "postcss-nested": "3.0.0",
-        "postcss-nesting": "6.0.0",
-        "postcss-remify": "1.0.1",
-        "postcss-scss": "1.0.6",
-        "postcss-simple-vars": "4.1.0",
-        "postcss-strip-inline-comments": "0.1.5",
-        "recursive-readdir": "2.2.2",
-        "speed-measure-webpack-plugin": "1.2.3",
-        "strip-ansi": "4.0.0",
-        "style-loader": "0.21.0",
-        "sw-precache-webpack-plugin": "0.11.5",
-        "thread-loader": "1.1.5",
-        "uglifyjs-webpack-plugin": "1.2.7",
-        "url-loader": "1.0.1",
-        "webpack": "4.14.0",
-        "webpack-manifest-plugin": "2.0.3",
-        "webpack-serve": "1.0.4",
-        "webpack-stylish": "0.1.8"
-    },
-    "devDependencies": {
-        "@semantic-release/git": "6.0.2",
-        "@vital-software/eslint-config": "1.6.3",
-        "@vital-software/renovate-config": "1.1.4",
-        "babel-eslint": "8.2.6",
-        "eslint": "5.8.0",
-        "eslint-plugin-babel": "5.2.1",
-        "eslint-plugin-compat": "2.6.3",
-        "eslint-plugin-filenames": "1.3.2",
-        "eslint-plugin-flowtype": "2.50.3",
-        "eslint-plugin-import": "2.14.0",
-        "eslint-plugin-jest": "22.0.0",
-        "eslint-plugin-jsx-a11y": "6.1.2",
-        "eslint-plugin-react": "7.11.1",
-        "husky": "0.14.3",
-        "semantic-release": "15.10.8"
-    },
-    "peerDependencies": {
-        "webpack-hot-client": "^4.0.4"
-    }
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
+      }
+    ],
+    "publish": [
+      "@semantic-release/npm",
+      "@semantic-release/github"
+    ]
+  },
+  "scripts": {
+    "lint": "eslint \"{bin,config,helper,scripts}/**/*.js\" --quiet",
+    "precommit": "yarn lint",
+    "test": "./test/task/local-test.sh"
+  },
+  "bin": {
+    "vitalizer": "./bin/vitalizer.js"
+  },
+  "dependencies": {
+    "@babel/core": "7.1.5",
+    "babel-loader": "8.0.4",
+    "browserslist": "4.3.4",
+    "case-sensitive-paths-webpack-plugin": "2.1.2",
+    "chalk": "2.4.1",
+    "connect-history-api-fallback": "1.5.0",
+    "cross-spawn": "6.0.5",
+    "css-loader": "0.28.11",
+    "dotenv": "6.1.0",
+    "dotenv-expand": "4.2.0",
+    "file-loader": "1.1.11",
+    "filesize": "3.6.1",
+    "fs-extra": "6.0.1",
+    "graphql": "0.13.2",
+    "graphql-tag": "2.10.0",
+    "gzip-size": "4.1.0",
+    "html-webpack-plugin": "3.2.0",
+    "http-proxy-middleware": "0.19.0",
+    "koa-connect": "2.0.1",
+    "koa-router": "7.4.0",
+    "mini-css-extract-plugin": "0.4.4",
+    "optimize-css-assets-webpack-plugin": "4.0.3",
+    "postcss-cssnext": "3.1.0",
+    "postcss-import": "11.1.0",
+    "postcss-loader": "2.1.6",
+    "postcss-nested": "3.0.0",
+    "postcss-nesting": "6.0.0",
+    "postcss-remify": "1.0.1",
+    "postcss-scss": "1.0.6",
+    "postcss-simple-vars": "4.1.0",
+    "postcss-strip-inline-comments": "0.1.5",
+    "postcss-url": "8.0.0",
+    "recursive-readdir": "2.2.2",
+    "speed-measure-webpack-plugin": "1.2.3",
+    "strip-ansi": "4.0.0",
+    "style-loader": "0.21.0",
+    "sw-precache-webpack-plugin": "0.11.5",
+    "thread-loader": "1.1.5",
+    "uglifyjs-webpack-plugin": "1.2.7",
+    "url-loader": "1.0.1",
+    "webpack": "4.14.0",
+    "webpack-manifest-plugin": "2.0.3",
+    "webpack-serve": "1.0.4",
+    "webpack-stylish": "0.1.8"
+  },
+  "devDependencies": {
+    "@semantic-release/git": "6.0.2",
+    "@vital-software/eslint-config": "1.6.3",
+    "@vital-software/renovate-config": "1.1.4",
+    "babel-eslint": "8.2.6",
+    "eslint": "5.8.0",
+    "eslint-plugin-babel": "5.2.1",
+    "eslint-plugin-compat": "2.6.3",
+    "eslint-plugin-filenames": "1.3.2",
+    "eslint-plugin-flowtype": "2.50.3",
+    "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-jest": "22.0.0",
+    "eslint-plugin-jsx-a11y": "6.1.2",
+    "eslint-plugin-react": "7.11.1",
+    "husky": "0.14.3",
+    "semantic-release": "15.10.8"
+  },
+  "peerDependencies": {
+    "webpack-hot-client": "^4.0.4"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,6 +2189,11 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -5262,7 +5267,7 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "~1.35.0"
 
-mime@^2.0.3, mime@^2.1.0:
+mime@^2.0.3, mime@^2.1.0, mime@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
   integrity sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==
@@ -7022,6 +7027,17 @@ postcss-unique-selectors@^2.0.2:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
+postcss-url@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-url/-/postcss-url-8.0.0.tgz#7b10059bd12929cdbb1971c60f61a0e5af86b4ca"
+  integrity sha512-E2cbOQ5aii2zNHh8F6fk1cxls7QVFZjLPSrqvmiza8OuXLzIpErij8BDS5Y3STPfJgpIMNCPEr8JlKQWEoozUw==
+  dependencies:
+    mime "^2.3.1"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.0"
+    postcss "^7.0.2"
+    xxhashjs "^0.2.1"
+
 postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
@@ -7063,6 +7079,15 @@ postcss@^6.0, postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.14, 
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.4.0"
+
+postcss@^7.0.2:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.6.tgz#6dcaa1e999cdd4a255dcd7d4d9547f4ca010cdc2"
+  integrity sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.5.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -8424,6 +8449,13 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
 svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
@@ -9290,6 +9322,13 @@ xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
+
+xxhashjs@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
## Purpose
Allows the CDN_URL environment variable to be set, and adds the URL as a prefix to JS/CSS assets. Requires testing on our staging environment.

## Approach
- Use `publicPath` in Webpack to configure JS assets
- Add PostCSS plugin to handle URL prefixing
