### PR TITLE
Only setup proxy if ENV vars are set

### DIFF
--- a/config/serve.config.js
+++ b/config/serve.config.js
@@ -61,18 +61,20 @@ module.exports = (host, port) => ({
         // Just a note, the order of statements matters here.
 
         // Set up API proxy first
-        app.use(
-            convert(
-                proxy('/api', {
-                    headers: {
-                        host: process.env.API_PROXY_HOST
-                    },
-                    pathRewrite: { ['^/api']: '' },
-                    secure: false,
-                    target: process.env.API_PROXY_URL
-                })
+        if (process.env.API_PROXY_HOST && process.env.API_PROXY_URL) {
+            app.use(
+                convert(
+                    proxy('/api', {
+                        headers: {
+                            host: process.env.API_PROXY_HOST
+                        },
+                        pathRewrite: { ['^/api']: '' },
+                        secure: false,
+                        target: process.env.API_PROXY_URL
+                    })
+                )
             )
-        )
+        }
 
         // Router needs to be added in this order.
         app.use(router.routes())


### PR DESCRIPTION
Trying to use Vitalizer with the `website`, and it doesn't need the Proxy. If I don't set the Proxy ENV variables, it throws an uncaught exception and kills the process... This prevents that.
