### PR TITLE
Add support for multiple HTML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ And set any of the following variables:
 | `CI`              | :large_orange_diamond: | :white_check_mark: | When set to `true`, Vitalizer treats warnings as failures in the build. Most CIs set this flag by default.                                                                          |
 | `DISABLE_HASH`.   | :x:                    | :white_check_mark: | When set to `true`, production assets are output as `[name].[ext]` rather than `[name][hash].[ext]`. Useful for debugging and test purposes.                                        |
 | `HOST`            | :white_check_mark:     |        :x:         | By default, the development web server binds to `localhost`. You may use this variable to specify a different host.                                                                 |
+| `INDEX_FILES`     | :white_check_mark:     | :white_check_mark: | Comma seperated list of HTML files to use. Defaults to `static/index.html`.                                                                                                         |
 | `PORT`            | :white_check_mark:     |        :x:         | By default, the development web server will attempt to listen on port 3000 or prompt you to attempt the next available port. You may use this variable to specify a different port. |
 | `RESOLVE_MODULES` | :white_check_mark:     | :white_check_mark: | Comma seperated list of module roots to use other than `node_modules`. i.e. `app, static`                                                                                           |
 

--- a/config/paths.js
+++ b/config/paths.js
@@ -4,13 +4,17 @@ const fs = require('fs')
 // https://github.com/facebook/create-react-app/issues/637
 const appDirectory = fs.realpathSync(process.cwd())
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath)
+// Use custom defined HTML files, or default to 'static/index.html'
+const defaultIndex = 'static/index.html'
+const htmlFiles = process.env.INDEX_FILES ? process.env.INDEX_FILES.replace(/\s+/g, '').split(',') : [defaultIndex]
 
 module.exports = {
     dotenv: resolveApp('.env'),
     appPath: resolveApp('.'),
     appBuild: resolveApp('public'),
     appPublic: resolveApp('static'),
-    appHtml: resolveApp('static/index.html'),
+    appIndexHtml: resolveApp(defaultIndex),
+    appHtmlFiles: htmlFiles.map(resolveApp),
     appIndexJs: resolveApp('app/index.js'),
     appSrc: resolveApp('app'),
     appNodeModules: resolveApp('node_modules')

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -193,10 +193,14 @@ module.exports = smp.wrap({
     },
 
     plugins: [
-        // Generates an `index.html` file with the <script> injected.
-        new HtmlWebpackPlugin({
-            template: paths.appHtml
-        }),
+        // Generates `index.html` files with the <script> injected.
+        ...paths.appHtmlFiles.map(
+            (filename) =>
+                new HtmlWebpackPlugin({
+                    filename: filename.replace('static', 'public'),
+                    template: filename
+                })
+        ),
 
         // Makes some environment variables available to the JS code.
         // It is absolutely essential that NODE_ENV was set to production here.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -18,6 +18,19 @@ const smp = new SpeedMeasurePlugin()
 const fileName = process.env.DISABLE_HASH ? '[name]' : '[name].[chunkhash:8]'
 // Configure CDN or local urls
 const publicPath = process.env.CDN_URL ? process.env.CDN_URL : '/'
+// HTML Minification
+const htmlMinifyOptions = {
+    collapseWhitespace: true,
+    removeComments: true,
+    removeRedundantAttributes: true,
+    useShortDoctype: true,
+    removeEmptyAttributes: true,
+    removeStyleLinkTypeAttributes: true,
+    keepClosingSlash: true,
+    minifyJS: true,
+    minifyCSS: true,
+    minifyURLs: true
+}
 
 /*
     This is the production configuration.
@@ -282,22 +295,15 @@ module.exports = smp.wrap({
     },
 
     plugins: [
-        // Generates an `index.html` file with the <script> injected.
-        new HtmlWebpackPlugin({
-            minify: {
-                collapseWhitespace: true,
-                removeComments: true,
-                removeRedundantAttributes: true,
-                useShortDoctype: true,
-                removeEmptyAttributes: true,
-                removeStyleLinkTypeAttributes: true,
-                keepClosingSlash: true,
-                minifyJS: true,
-                minifyCSS: true,
-                minifyURLs: true
-            },
-            template: paths.appHtml
-        }),
+        // Generates `index.html` files with the <script> injected.
+        ...paths.appHtmlFiles.map(
+            (filename) =>
+                new HtmlWebpackPlugin({
+                    filename: filename.replace('static', 'public'),
+                    minify: htmlMinifyOptions,
+                    template: filename
+                })
+        ),
 
         // Makes some environment variables available to the JS code.
         // It is absolutely essential that NODE_ENV was set to production here.

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,12 +30,12 @@ const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024
 function copyPublicFolder() {
     fs.copySync(paths.appPublic, paths.appBuild, {
         dereference: true,
-        filter: (file) => file !== paths.appHtml
+        filter: (file) => file !== paths.appIndexHtml
     })
 }
 
 // Warn and crash if required files are missing
-if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
+if (!checkRequiredFiles([paths.appIndexHtml, paths.appIndexJs])) {
     process.exit(1)
 }
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -18,7 +18,7 @@ const { checkBrowsers, printBrowsers } = require('../helper/browsers')
 const checkRequiredFiles = require('../helper/check-required-files')
 
 // Warn and crash if required files are missing
-if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
+if (!checkRequiredFiles([paths.appIndexHtml, paths.appIndexJs])) {
     process.exit(1)
 }
 

--- a/test/.env
+++ b/test/.env
@@ -1,4 +1,5 @@
 API_PROXY_HOST=api.vital
 API_PROXY_URL=https://${API_PROXY_HOST}
 DISABLE_HASH=true
+INDEX_FILES=static/index.html, static/careers/index.html
 RESOLVE_MODULES=app/sass, app, static

--- a/test/static/careers/index.html
+++ b/test/static/careers/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
 
-        <title>Test HTML</title>
+        <title>Test Careers HTML</title>
     </head>
     <body>
         <div id="root"></div>


### PR DESCRIPTION
## Purpose
The current version of `vitalizer` is only designed to work with a single HTML page. This adds basic support for additional HTML output files.

## Approach
- Add `INDEX_FILES` environment variable support

This approach is a little bit of an escape hatch. We may need to create a "SPA" version of Vitalizer, and a "Website" version to better support different use cases.