### PR TITLE
Remove API middleware config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,15 @@ VARIABLE=name
 
 And set any of the following variables:
 
-| Variable          | Development            |     Production     | Usage                                                                                                                                                                               |
-| :---------------- | :--------------------- | :----------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `API_PROXY_HOST`  | :white_check_mark:     |        :x:         | Set this value to configure the API proxy host (i.e. `api.vital`)                                                                                                                   |
-| `API_PROXY_URL`   | :white_check_mark:     |        :x:         | Set this value to configure the API proxy url (i.e. `https://api.vital`)                                                                                                            |
-| `CDN_URL`         | :x:                    | :white_check_mark: | When set, production assets are output as `[CDN_URL][asset]` rather than `[asset]`. Used to support an external CDN for assets.                                                     |
-| `CI`              | :large_orange_diamond: | :white_check_mark: | When set to `true`, Vitalizer treats warnings as failures in the build. Most CIs set this flag by default.                                                                          |
-| `DISABLE_HASH`.   | :x:                    | :white_check_mark: | When set to `true`, production assets are output as `[name].[ext]` rather than `[name][hash].[ext]`. Useful for debugging and test purposes.                                        |
-| `HOST`            | :white_check_mark:     |        :x:         | By default, the development web server binds to `localhost`. You may use this variable to specify a different host.                                                                 |
-| `INDEX_FILES`     | :white_check_mark:     | :white_check_mark: | Comma seperated list of HTML files to use. Defaults to `static/index.html`.                                                                                                         |
-| `PORT`            | :white_check_mark:     |        :x:         | By default, the development web server will attempt to listen on port 3000 or prompt you to attempt the next available port. You may use this variable to specify a different port. |
-| `RESOLVE_MODULES` | :white_check_mark:     | :white_check_mark: | Comma seperated list of module roots to use other than `node_modules`. i.e. `app, static`                                                                                           |
+| Variable | Development | Production | Usage |
+| :---------------- | :--------------------- | :----------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | |
+| `CDN_URL` | :x: | :white_check_mark: | When set, production assets are output as `[CDN_URL][asset]` rather than `[asset]`. Used to support an external CDN for assets. |
+| `CI` | :large_orange_diamond: | :white_check_mark: | When set to `true`, Vitalizer treats warnings as failures in the build. Most CIs set this flag by default. |
+| `DISABLE_HASH`. | :x: | :white_check_mark: | When set to `true`, production assets are output as `[name].[ext]` rather than `[name][hash].[ext]`. Useful for debugging and test purposes. |
+| `HOST` | :white_check_mark: | :x: | By default, the development web server binds to `localhost`. You may use this variable to specify a different host. |
+| `INDEX_FILES` | :white_check_mark: | :white_check_mark: | Comma seperated list of HTML files to use. Defaults to `static/index.html`. |
+| `PORT` | :white_check_mark: | :x: | By default, the development web server will attempt to listen on port 3000 or prompt you to attempt the next available port. You may use this variable to specify a different port. |
+| `RESOLVE_MODULES` | :white_check_mark: | :white_check_mark: | Comma seperated list of module roots to use other than `node_modules`. i.e. `app, static` |
 
 #### Expanding Environment Variables In .env
 

--- a/config/serve.config.js
+++ b/config/serve.config.js
@@ -5,7 +5,6 @@ const config = require('./webpack.config.dev')
 const convert = require('koa-connect')
 const history = require('connect-history-api-fallback')
 const paths = require('./paths')
-const proxy = require('http-proxy-middleware')
 const Router = require('koa-router')
 // Create router definition
 const router = new Router()
@@ -59,22 +58,6 @@ module.exports = (host, port) => ({
 
     add: (app, middleware) => {
         // Just a note, the order of statements matters here.
-
-        // Set up API proxy first
-        if (process.env.API_PROXY_HOST && process.env.API_PROXY_URL) {
-            app.use(
-                convert(
-                    proxy('/api', {
-                        headers: {
-                            host: process.env.API_PROXY_HOST
-                        },
-                        pathRewrite: { ['^/api']: '' },
-                        secure: false,
-                        target: process.env.API_PROXY_URL
-                    })
-                )
-            )
-        }
 
         // Router needs to be added in this order.
         app.use(router.routes())

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "graphql-tag": "2.10.0",
     "gzip-size": "5.0.0",
     "html-webpack-plugin": "3.2.0",
-    "http-proxy-middleware": "0.19.1",
     "koa-connect": "2.0.1",
     "koa-router": "7.4.0",
     "mini-css-extract-plugin": "0.5.0",

--- a/test/.env
+++ b/test/.env
@@ -1,5 +1,3 @@
-API_PROXY_HOST=api.vital
-API_PROXY_URL=https://${API_PROXY_HOST}
 DISABLE_HASH=true
 INDEX_FILES=static/index.html, static/careers/index.html
 RESOLVE_MODULES=app/sass, app, static

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,7 +2225,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -2951,11 +2951,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
-eventemitter3@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
-  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
-
 events@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -3237,13 +3232,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
-
-follow-redirects@^1.0.0:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -3778,25 +3766,6 @@ http-proxy-agent@^2.1.0:
   dependencies:
     agent-base "4"
     debug "3.1.0"
-
-http-proxy-middleware@0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
-  integrity sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==
-  dependencies:
-    http-proxy "^1.17.0"
-    is-glob "^4.0.0"
-    lodash "^4.17.11"
-    micromatch "^3.1.10"
-
-http-proxy@^1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
-  integrity sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==
-  dependencies:
-    eventemitter3 "^3.0.0"
-    follow-redirects "^1.0.0"
-    requires-port "^1.0.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -7765,11 +7734,6 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Purpose
Now that `/api` is handled by `stack`, there is no need to keep this functionality supported within `vitalizer`.

## Approach
- Remove `/api` support
- Remove HTTP Middleware package
- Remove ENV variables used to configure `/api` middleware
