### PR TITLE
Improve TypeScript support

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -15,7 +15,7 @@ module.exports = {
     appPublic: resolveApp('static'),
     appIndexHtml: resolveApp(defaultIndex),
     appHtmlFiles: htmlFiles.map(resolveApp),
-    appIndexJs: resolveApp('app/index.js'),
+    appIndexJs: resolveApp('app/index.tsx'),
     appSrc: resolveApp('app'),
     appNodeModules: resolveApp('node_modules')
 }

--- a/config/paths.js
+++ b/config/paths.js
@@ -15,7 +15,7 @@ module.exports = {
     appPublic: resolveApp('static'),
     appIndexHtml: resolveApp(defaultIndex),
     appHtmlFiles: htmlFiles.map(resolveApp),
-    appIndexJs: resolveApp('app/index.tsx'),
+    appIndexTsx: resolveApp('app/index.tsx'),
     appSrc: resolveApp('app'),
     appNodeModules: resolveApp('node_modules')
 }

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -24,7 +24,7 @@ module.exports = smp.wrap({
     devtool: 'cheap-module-source-map',
 
     entry: [
-        paths.appIndexJs
+        paths.appIndexTsx
         // We include the app code last so that if there is a runtime error during
         // initialization, it doesn't blow up Webpack Serve, and
         // changing JS code would still trigger a refresh.

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -73,7 +73,7 @@ module.exports = smp.wrap({
             : ['node_modules'],
 
         // These are the reasonable defaults supported by the Node ecosystem.
-        extensions: ['.gql', '.graphql', '.mjs', '.js', '.json', '.jsx', '.flow', '.css', '.scss', '.ts', '.tsx'],
+        extensions: ['.gql', '.graphql', '.mjs', '.js', '.json', '.jsx', '.flow', '.ts', '.tsx'],
         // Alias react dom to allow hot loader to patch it for new react features: https://github.com/gaearon/react-hot-loader#react--dom
         alias: {
             'react-dom': '@hot-loader/react-dom'

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -51,7 +51,7 @@ module.exports = smp.wrap({
     performance: false,
 
     // In production, we only want the app code.
-    entry: paths.appIndexJs,
+    entry: paths.appIndexTsx,
 
     output: {
         // The output directory as an absolute path.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -186,7 +186,7 @@ module.exports = smp.wrap({
             : ['node_modules'],
 
         // These are the reasonable defaults supported by the Node ecosystem.
-        extensions: ['.gql', '.graphql', '.mjs', '.js', '.json', '.jsx', '.flow', '.css', '.scss', '.ts', '.tsx']
+        extensions: ['.gql', '.graphql', '.mjs', '.js', '.json', '.jsx', '.flow', '.ts', '.tsx']
     },
 
     module: {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -35,7 +35,7 @@ function copyPublicFolder() {
 }
 
 // Warn and crash if required files are missing
-if (!checkRequiredFiles([paths.appIndexHtml, paths.appIndexJs])) {
+if (!checkRequiredFiles([paths.appIndexHtml, paths.appIndexTsx])) {
     process.exit(1)
 }
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -27,7 +27,7 @@ const compiler = webpack(webpackConfig)
 const devServer = new WebpackDevServer(compiler, devServerOptions)
 
 // Warn and crash if required files are missing
-if (!checkRequiredFiles([paths.appIndexHtml, paths.appIndexJs])) {
+if (!checkRequiredFiles([paths.appIndexHtml, paths.appIndexTsx])) {
     process.exit(1)
 }
 

--- a/test/app/index.tsx
+++ b/test/app/index.tsx
@@ -1,4 +1,3 @@
-// @flow
 import BaseComponent from './base-component'
 import { BrowserRouter } from 'react-router-dom'
 import { Provider } from 'react-redux'
@@ -6,7 +5,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import { Route } from 'react-router'
 
-const path: string = '/'
+const path = '/'
 
 render(
     <Provider store={{}}>


### PR DESCRIPTION
## Purpose
`.css` and `.scss` module resolution was taking precedence over TypeScript files, and as such, was breaking certain imported modules because TSX and CSS files had the same name in the same directory (co-located). Furthermore, `index.js` was the only supported Index file name, this is now `index.tsx` instead.

## Breaking Change
`.css` and `.scss` module resolution no longer works, i.e you now need to do this for stylesheet imports:
`import 'index.css'` => instead of `import 'index'`