### PR TITLE
Configure CSS Modules through Webpack.

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -136,6 +136,7 @@ module.exports = smp.wrap({
                     // By default we support CSS Modules with the extension .module.css
                     {
                         test: /\.(css|scss)$/,
+                        exclude: /\.module.css$/,
                         use: [
                             {
                                 loader: 'style-loader', // Add CSS to HTML page (uses JavaScript)
@@ -162,6 +163,34 @@ module.exports = smp.wrap({
                                     // https://github.com/facebook/create-react-app/issues/2677
                                     ident: 'postcss',
 
+                                    sourceMap: true
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        test: /\.module.css$/,
+                        use: [
+                            {
+                                loader: 'style-loader',
+                                options: { sourceMap: true }
+                            },
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    importLoaders: 1,
+                                    sourceMap: true,
+                                    modules: true,
+                                    localIdentName: '[name]--[local]--[hash:base64:5]'
+                                }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: {
+                                    config: {
+                                        path: path.join(__dirname, './postcss.config.js')
+                                    },
+                                    ident: 'postcss',
                                     sourceMap: true
                                 }
                             }

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -237,6 +237,7 @@ module.exports = smp.wrap({
                     // By default we support CSS Modules with the extension .module.css
                     {
                         test: /\.(css|scss)$/,
+                        exclude: /\.module.css$/,
                         use: [
                             MiniCssExtractPlugin.loader,
                             {
@@ -260,6 +261,31 @@ module.exports = smp.wrap({
                                     // https://github.com/facebook/create-react-app/issues/2677
                                     ident: 'postcss',
 
+                                    sourceMap: true
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        test: /\.module.css$/,
+                        use: [
+                            MiniCssExtractPlugin.loader,
+                            {
+                                loader: 'css-loader',
+                                options: {
+                                    importLoaders: 1,
+                                    sourceMap: true,
+                                    modules: true,
+                                    localIdentName: '[name]--[local]--[hash:base64:5]'
+                                }
+                            },
+                            {
+                                loader: 'postcss-loader',
+                                options: {
+                                    config: {
+                                        path: path.join(__dirname, './postcss.config.js')
+                                    },
+                                    ident: 'postcss',
                                     sourceMap: true
                                 }
                             }


### PR DESCRIPTION
Any files ending with .module.css will enable the `modules` option in the `css-loader` in webpack.
All non-module `.css` and `.scss` files will still be loaded the old way. 