### PR TITLE
Switch to nosource Source Map for Sentry support

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -44,7 +44,7 @@ module.exports = smp.wrap({
     bail: true,
 
     // We generate sourcemaps in production. This is slow but gives good results.
-    devtool: 'source-map',
+    devtool: 'nosources-source-map',
 
     // Turn off performance processing because we utilize
     // our own hints via the FileSizeReporter.


### PR DESCRIPTION
Sentry docs https://docs.sentry.io/platforms/javascript/#webpack explain that the `noSources` option should be set to `false` for Sentry Source Map support, this changes our devtool format to match in Webpack.
