### PR TITLE
Replace [chunkhash] with [contenthash]

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -15,7 +15,7 @@ const webpack = require('webpack')
 // Measure the speed of the build
 const smp = new SpeedMeasurePlugin()
 // Configure file names to use hashing or not
-const fileName = process.env.DISABLE_HASH ? '[name]' : '[name].[hash:8]'
+const fileName = process.env.DISABLE_HASH ? '[name]' : '[name].[contenthash:8]'
 // Configure CDN or local urls
 const publicPath = process.env.CDN_URL ? process.env.CDN_URL : '/'
 // HTML Minification

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -15,7 +15,7 @@ const webpack = require('webpack')
 // Measure the speed of the build
 const smp = new SpeedMeasurePlugin()
 // Configure file names to use hashing or not
-const fileName = process.env.DISABLE_HASH ? '[name]' : '[name].[chunkhash:8]'
+const fileName = process.env.DISABLE_HASH ? '[name]' : '[name].[hash:8]'
 // Configure CDN or local urls
 const publicPath = process.env.CDN_URL ? process.env.CDN_URL : '/'
 // HTML Minification
@@ -118,8 +118,8 @@ module.exports = smp.wrap({
         // Support multiple path module lookup (i.e. app/sass module root support).
         modules: process.env.RESOLVE_MODULES
             ? ['node_modules']
-                .concat(process.env.RESOLVE_MODULES.split(',').map((string) => string.trim()))
-                .map(paths.resolveApp)
+                  .concat(process.env.RESOLVE_MODULES.split(',').map((string) => string.trim()))
+                  .map(paths.resolveApp)
             : ['node_modules'],
 
         // These are the reasonable defaults supported by the Node ecosystem.


### PR DESCRIPTION
Was breaking when trying to load woff2 fonts through the file loader. 

**Error in Patient:**
![image](https://user-images.githubusercontent.com/61799/76175638-66b08800-6212-11ea-8064-d4389d920cc8.png)

~~Github Issue with solution~~
~~https://github.com/webpack/webpack/issues/991~~

**Actual solution**
The actual solution is to use `contenthash`
This fixes the font loading issue and retains the per file hash value.

Explanation of `hash` vs `chunkhash` vs `contenthash`
https://medium.com/@sahilkkrazy/hash-vs-chunkhash-vs-contenthash-e94d38a32208
