### PR TITLE
Allow external connections to the webpack dev server

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -34,7 +34,7 @@ if (!checkRequiredFiles([paths.appIndexHtml, paths.appIndexTsx])) {
 
 // Locate HOST/PORT
 const PORT = parseInt(process.env.PORT, 10) || 3000
-const HOST = process.env.HOST || '0.0.0.0'
+const HOST = '0.0.0.0'
 
 checkBrowsers(paths.appPath)
     .then(() => printBrowsers(paths.appPath))


### PR DESCRIPTION
Explicitly set the Host to `0.0.0.0`

`process.env.HOST` was setting it to `localhost` which blocked external connections. 

