### PR TITLE
Move svg loader from devDeps to deps

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,27 @@
+### NPM via Semantic Release
+
+We use [Semantic Release](https://github.com/semantic-release/semantic-release) to manage releases of the Component Library to the NPM Registry.
+
+By following the commit message template below, Semantic Release can determine what version number the next release should be.
+
+```
+Tag: Short description (fixes #1234)
+
+Longer description here if necessary
+```
+
+The `Tag` should be replaced with one of the following:
+
+- `Fix` - for a bug fix.
+- `Update` - either for a backwards-compatible enhancement or for a rule change that adds reported problems.
+- `New` - implemented a new feature.
+- `Breaking` - for a backwards-incompatible enhancement or feature.
+- `Docs` - changes to documentation only.
+- `Build` - changes to build process only.
+- `Upgrade` - for a dependency upgrade.
+- `Chore` - for refactoring, adding tests, etc. (anything that isn’t user-facing).
+
+Each of these tags corresponds to either a `Major`, `Minor` or `Patch` release.
+
+**Note:** Only the squashed merge commit into `master` needs to follow this commit template.
+

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "postcss-strip-inline-comments": "0.1.5",
     "postcss-url": "8.0.0",
     "qrcode": "1.4.4",
+    "react-svg-loader": "3.0.3",
     "recursive-readdir": "2.2.2",
     "speed-measure-webpack-plugin": "1.3.1",
     "strip-ansi": "6.0.0",
@@ -87,7 +88,6 @@
     "conventional-changelog-eslint": "3.0.4",
     "eslint": "6.8.0",
     "husky": "4.2.3",
-    "react-svg-loader": "3.0.3",
     "semantic-release": "17.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Was giving a `module not found` error, for `react-svg-loader`