### PR TITLE
New: Add webpack-stats-plugin support

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,7 @@
 env:
-  COMMIT_TAG: vitalizer-${BUILDKITE_COMMIT}
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_0: "docker-compose.yml"
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_CONFIG_1: "docker-compose.buildkite.yml"
+  BUILDKITE_PLUGIN_DOCKER_COMPOSE_IMAGE_REPOSITORY: "quay.io/vital/build-cache"
 
 steps:
   - name: ":docker: :quay: Build and push container to Quay"
@@ -7,32 +9,25 @@ steps:
     agents:
       queue: docker-build
     plugins:
-      vital-software/docker-compose#vital-v1.8:
-        build: base
-        image_repository: quay.io/vital/build-cache
-        image-name: ${COMMIT_TAG}
+      - docker-compose#v3.3.0:
+          build: base
+          image-name: "vitalizer-${BUILDKITE_COMMIT}-${BUILDKITE_BUILD_NUMBER}"
 
   - name: ":eslint: Lint"
     key: linting
     depends_on: create-image
     command: yarn lint
     plugins:
-      vital-software/docker-compose#vital-v1.8:
-        config:
-          - docker-compose.yml
-          - docker-compose.buildkite.yml
-        run: base
+      - docker-compose#v3.3.0:
+          run: base
 
   - name: ":yarn: Run Tests"
     key: tests
     depends_on: create-image
     command: test/task/e2e-simple.sh
     plugins:
-      vital-software/docker-compose#vital-v1.8:
-        config:
-          - docker-compose.yml
-          - docker-compose.buildkite.yml
-        run: base
+      - docker-compose#v3.3.0:
+          run: base
 
   - name: ":npm: :github: Release package to Github Registry"
     depends_on:
@@ -42,8 +37,5 @@ steps:
     command: semantic-release
     timeout_in_minutes: 2
     plugins:
-      vital-software/docker-compose#vital-v1.8:
-        config:
-          - docker-compose.yml
-          - docker-compose.buildkite.yml
-        run: base
+      - docker-compose#v3.3.0:
+          run: base

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ And set any of the following variables:
 | `INDEX_FILES`     | :white_check_mark:     | :white_check_mark: | Comma seperated list of HTML files to use. Defaults to `static/index.html`.                                                                                                         |
 | `PORT`            | :white_check_mark:     | :x:                | By default, the development web server will attempt to listen on port 3000 or prompt you to attempt the next available port. You may use this variable to specify a different port. |
 | `RESOLVE_MODULES` | :white_check_mark:     | :white_check_mark: | Comma seperated list of module roots to use other than `node_modules`. i.e. `app, static`                                                                                           |
-| `BUNDLE_ANALYZER_TOKEN ` | n/a | :x: | If specified, on build webpack will upload a summary of production bundle sizes to bundle-analyzer |
+| `BUNDLE_ANALYZER_TOKEN` | n/a | :x: | If specified, on build webpack will upload a summary of production bundle sizes to bundle-analyzer |
+| `WEBPACK_STATS` | n/a | :x: | When set to any value, on build webpack will write build statistics JSON to stats.json in the output directory |
 
 We also support overriding the **Webpack Dev Server** settings by creating a `serve.config.dev.js` file in your project root, and using [applicable Webpack Dev Server config syntax](https://webpack.js.org/configuration/dev-server/).
 

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -10,6 +10,7 @@ const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const path = require('path')
 const paths = require('./paths')
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin')
+const { StatsWriterPlugin } = require('webpack-stats-plugin')
 const StylishWebpackPlugin = require('webpack-stylish')
 const TerserPlugin = require('terser-webpack-plugin')
 const webpack = require('webpack')
@@ -327,5 +328,19 @@ module.exports = smp.wrap({
         process.env.BUNDLE_ANALYZER_TOKEN
             ? [new BundleAnalyzerPlugin({ token: process.env.BUNDLE_ANALYZER_TOKEN })]
             : []
-    ),
+    )        .concat(
+        process.env.WEBPACK_STATS
+            ? [
+                new StatsWriterPlugin({
+                    filename: '../stats.json',
+                    fields: null,
+                    stats: {
+                        maxModules: Infinity,
+                        source: false,
+                    },
+                }),
+            ]
+            : []
+    )
+    ,
 })

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -324,23 +324,24 @@ module.exports = smp.wrap({
 
         // Custom format webpack stats output so it doesn't look shit.
         new StylishWebpackPlugin(),
-    ].concat(
-        process.env.BUNDLE_ANALYZER_TOKEN
-            ? [new BundleAnalyzerPlugin({ token: process.env.BUNDLE_ANALYZER_TOKEN })]
-            : []
-    )        .concat(
-        process.env.WEBPACK_STATS
-            ? [
-                new StatsWriterPlugin({
-                    filename: '../stats.json',
-                    fields: null,
-                    stats: {
-                        maxModules: Infinity,
-                        source: false,
-                    },
-                }),
-            ]
-            : []
-    )
-    ,
+    ]
+        .concat(
+            process.env.BUNDLE_ANALYZER_TOKEN
+                ? [new BundleAnalyzerPlugin({ token: process.env.BUNDLE_ANALYZER_TOKEN })]
+                : []
+        )
+        .concat(
+            process.env.WEBPACK_STATS
+                ? [
+                      new StatsWriterPlugin({
+                          filename: '../stats.json',
+                          fields: null,
+                          stats: {
+                              maxModules: Infinity,
+                              source: false,
+                          },
+                      }),
+                  ]
+                : []
+        ),
 })

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "conventional-changelog-eslint": "3.0.4",
     "eslint": "6.8.0",
     "husky": "4.2.3",
+    "prettier": "2.0.5",
     "semantic-release": "17.0.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "webpack": "4.40.2",
     "webpack-dev-server": "3.9.0",
     "webpack-manifest-plugin": "2.2.0",
+    "webpack-stats-plugin": "0.3.1",
     "webpack-stylish": "0.1.8",
     "workbox-webpack-plugin": "4.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8292,6 +8292,11 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10626,6 +10626,11 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-stats-plugin@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/webpack-stats-plugin/-/webpack-stats-plugin-0.3.1.tgz#1103c39a305a4e6ba15d5078db84bc0b35447417"
+  integrity sha512-pxqzFE055NlNTlNyfDG3xlB2QwT1EWdm/CF5dCJI/e+rRHVxrWhWg1rf1lfsWhI1/EePv8gi/A36YxO/+u0FgQ==
+
 webpack-stylish@0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/webpack-stylish/-/webpack-stylish-0.1.8.tgz#96fdcae798a698f6b5983931bb08042bc04cf7ac"


### PR DESCRIPTION
If `WEBPACK_STATS` is set, writes the stats out to `../stats.json` (without us having to redirect stdout of the actual build or something similar) relative to the outputPath (so that it isn't captured by any later zipping or deploying we do)

This basically does the same stats.json exporting that we've done in a bit of custom code, but wrapped in a plugin so it's easy to use.