### PR TITLE
Add `BUILD_DIR` support to configure output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,17 @@ And set any of the following variables:
 
 | Variable                | Development            | Production         | Usage                                                                                                                                                                               |
 | :---------------------- | :--------------------- | :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BUILD_DIR`             | :x:                    | :white_check_mark: | Output directory to build files to. Defaults to `public`.                                                                                                                           |
+| `BUNDLE_ANALYZER_TOKEN` | :x:                    | :white_check_mark: | If specified, on build webpack will upload a summary of production bundle sizes to bundle-analyzer                                                                                  |
 | `CDN_URL`               | :x:                    | :white_check_mark: | When set, production assets are output as `[CDN_URL][asset]` rather than `[asset]`. Used to support an external CDN for assets.                                                     |
 | `CI`                    | :large_orange_diamond: | :white_check_mark: | When set to `true`, Vitalizer treats warnings as failures in the build. Most CIs set this flag by default.                                                                          |
 | `DISABLE_HASH`.         | :x:                    | :white_check_mark: | When set to `true`, production assets are output as `[name].[ext]` rather than `[name][hash].[ext]`. Useful for debugging and test purposes.                                        |
 | `HOST`                  | :white_check_mark:     | :x:                | By default, the development web server binds to `localhost`. You may use this variable to specify a different host.                                                                 |
-| `INDEX_FILES`           | :white_check_mark:     | :white_check_mark: | Comma seperated list of HTML files to use. Defaults to `static/index.html`.                                                                                                         |
+| `INDEX_FILES`           | :white_check_mark:     | :white_check_mark: | Comma seperated list of HTML files to use. Defaults to `static/index.html`.html`.                                                                                                   |
 | `PORT`                  | :white_check_mark:     | :x:                | By default, the development web server will attempt to listen on port 3000 or prompt you to attempt the next available port. You may use this variable to specify a different port. |
 | `RESOLVE_MODULES`       | :white_check_mark:     | :white_check_mark: | Comma seperated list of module roots to use other than `node_modules`. i.e. `app, static`                                                                                           |
-| `BUNDLE_ANALYZER_TOKEN` | n/a                    | :x:                | If specified, on build webpack will upload a summary of production bundle sizes to bundle-analyzer                                                                                  |
-| `WEBPACK_STATS`         | n/a                    | :x:                | When set to any value, on build webpack will write build statistics JSON to stats.json in the output directory                                                                      |
+
+| `WEBPACK_STATS` | n/a | :x: | When set to any value, on build webpack will write build statistics JSON to stats.json in the output directory |
 
 We also support overriding the **Webpack Dev Server** settings by creating a `serve.config.dev.js` file in your project root, and using [applicable Webpack Dev Server config syntax](https://webpack.js.org/configuration/dev-server/).
 

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ VARIABLE=name
 
 And set any of the following variables:
 
-| Variable          | Development            | Production         | Usage                                                                                                                                                                               |
-| :---------------- | :--------------------- | :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CDN_URL`         | :x:                    | :white_check_mark: | When set, production assets are output as `[CDN_URL][asset]` rather than `[asset]`. Used to support an external CDN for assets.                                                     |
-| `CI`              | :large_orange_diamond: | :white_check_mark: | When set to `true`, Vitalizer treats warnings as failures in the build. Most CIs set this flag by default.                                                                          |
-| `DISABLE_HASH`.   | :x:                    | :white_check_mark: | When set to `true`, production assets are output as `[name].[ext]` rather than `[name][hash].[ext]`. Useful for debugging and test purposes.                                        |
-| `HOST`            | :white_check_mark:     | :x:                | By default, the development web server binds to `localhost`. You may use this variable to specify a different host.                                                                 |
-| `INDEX_FILES`     | :white_check_mark:     | :white_check_mark: | Comma seperated list of HTML files to use. Defaults to `static/index.html`.                                                                                                         |
-| `PORT`            | :white_check_mark:     | :x:                | By default, the development web server will attempt to listen on port 3000 or prompt you to attempt the next available port. You may use this variable to specify a different port. |
-| `RESOLVE_MODULES` | :white_check_mark:     | :white_check_mark: | Comma seperated list of module roots to use other than `node_modules`. i.e. `app, static`                                                                                           |
-| `BUNDLE_ANALYZER_TOKEN` | n/a | :x: | If specified, on build webpack will upload a summary of production bundle sizes to bundle-analyzer |
-| `WEBPACK_STATS` | n/a | :x: | When set to any value, on build webpack will write build statistics JSON to stats.json in the output directory |
+| Variable                | Development            | Production         | Usage                                                                                                                                                                               |
+| :---------------------- | :--------------------- | :----------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CDN_URL`               | :x:                    | :white_check_mark: | When set, production assets are output as `[CDN_URL][asset]` rather than `[asset]`. Used to support an external CDN for assets.                                                     |
+| `CI`                    | :large_orange_diamond: | :white_check_mark: | When set to `true`, Vitalizer treats warnings as failures in the build. Most CIs set this flag by default.                                                                          |
+| `DISABLE_HASH`.         | :x:                    | :white_check_mark: | When set to `true`, production assets are output as `[name].[ext]` rather than `[name][hash].[ext]`. Useful for debugging and test purposes.                                        |
+| `HOST`                  | :white_check_mark:     | :x:                | By default, the development web server binds to `localhost`. You may use this variable to specify a different host.                                                                 |
+| `INDEX_FILES`           | :white_check_mark:     | :white_check_mark: | Comma seperated list of HTML files to use. Defaults to `static/index.html`.                                                                                                         |
+| `PORT`                  | :white_check_mark:     | :x:                | By default, the development web server will attempt to listen on port 3000 or prompt you to attempt the next available port. You may use this variable to specify a different port. |
+| `RESOLVE_MODULES`       | :white_check_mark:     | :white_check_mark: | Comma seperated list of module roots to use other than `node_modules`. i.e. `app, static`                                                                                           |
+| `BUNDLE_ANALYZER_TOKEN` | n/a                    | :x:                | If specified, on build webpack will upload a summary of production bundle sizes to bundle-analyzer                                                                                  |
+| `WEBPACK_STATS`         | n/a                    | :x:                | When set to any value, on build webpack will write build statistics JSON to stats.json in the output directory                                                                      |
 
 We also support overriding the **Webpack Dev Server** settings by creating a `serve.config.dev.js` file in your project root, and using [applicable Webpack Dev Server config syntax](https://webpack.js.org/configuration/dev-server/).
 

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,9 +1,11 @@
 const path = require('path')
 const fs = require('fs')
+
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
 const appDirectory = fs.realpathSync(process.cwd())
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath)
+
 // Use custom defined HTML files, or default to 'static/index.html'
 const defaultIndex = 'static/index.html'
 const htmlFiles = process.env.INDEX_FILES ? process.env.INDEX_FILES.replace(/\s+/g, '').split(',') : [defaultIndex]
@@ -12,7 +14,6 @@ module.exports = {
     appBabelConfig: resolveApp('.babelrc'),
     appBuild: resolveApp('public'),
     appComponentLibrary: resolveApp('node_modules/@vital-software/components'),
-    appHtmlFiles: htmlFiles.map(resolveApp),
     appIndexHtml: resolveApp(defaultIndex),
     appIndexTsx: resolveApp('app/index.tsx'),
     appNodeModules: resolveApp('node_modules'),
@@ -22,6 +23,6 @@ module.exports = {
     appDevServerConfig: resolveApp('serve.config.dev.js'),
     appWebpackDevConfig: resolveApp('webpack.config.dev.js'),
     dotenv: resolveApp('.vitalizer'),
+    htmlFiles,
+    resolveApp
 }
-
-module.exports.resolveApp = resolveApp

--- a/config/paths.js
+++ b/config/paths.js
@@ -10,9 +10,12 @@ const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath)
 const defaultIndex = 'static/index.html'
 const htmlFiles = process.env.INDEX_FILES ? process.env.INDEX_FILES.replace(/\s+/g, '').split(',') : [defaultIndex]
 
+// Use custom defined build output folder, or default to 'public'
+const buildDirectoryFolderName = process.env.BUILD_DIR ? process.env.BUILD_DIR : 'public'
+
 module.exports = {
     appBabelConfig: resolveApp('.babelrc'),
-    appBuild: resolveApp('public'),
+    appBuild: resolveApp(buildDirectoryFolderName),
     appComponentLibrary: resolveApp('node_modules/@vital-software/components'),
     appIndexHtml: resolveApp(defaultIndex),
     appIndexTsx: resolveApp('app/index.tsx'),

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -244,10 +244,10 @@ module.exports = smp.wrap({
 
     plugins: [
         // Generates `index.html` files with the <script> injected.
-        ...paths.appHtmlFiles.map(
+        ...paths.htmlFiles.map(
             (filename) =>
                 new HtmlWebpackPlugin({
-                    filename: filename.replace('static', 'public'),
+                    filename: filename.replace('static/', ''),
                     template: filename,
                 })
         ),

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -14,12 +14,16 @@ const { StatsWriterPlugin } = require('webpack-stats-plugin')
 const StylishWebpackPlugin = require('webpack-stylish')
 const TerserPlugin = require('terser-webpack-plugin')
 const webpack = require('webpack')
+
 // Measure the speed of the build
 const smp = new SpeedMeasurePlugin()
+
 // Configure file names to use hashing or not
 const fileName = process.env.DISABLE_HASH ? '[name]' : '[name].[contenthash:8]'
+
 // Configure CDN or local urls
 const publicPath = process.env.CDN_URL ? process.env.CDN_URL : '/'
+
 // HTML Minification
 const htmlMinifyOptions = {
     collapseWhitespace: true,
@@ -280,10 +284,10 @@ module.exports = smp.wrap({
 
     plugins: [
         // Generates `index.html` files with the <script> injected.
-        ...paths.appHtmlFiles.map(
+        ...paths.htmlFiles.map(
             (filename) =>
                 new HtmlWebpackPlugin({
-                    filename: filename.replace('static', 'public'),
+                    filename: filename.replace('static/', ''),
                     minify: htmlMinifyOptions,
                     template: filename,
                 })


### PR DESCRIPTION
## Purpose
In order to support deploying assets for use on a CDN, we need to be able to configure the output directory. By setting `BUILD_DIR`, scripts can now have more control of where compiled assets end up.

## Approach
- Improve Readme formatting
- Simplify paths file
- Remove `public` references in config files (defeats the point of having a paths config file...)
- Configure `appBuild` using BUILD_DIR ENV value or default to `public`